### PR TITLE
rewrite trello gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Overview
-Generates trello cards on a specified board for all open issues in specified github repo(s). 
+Generates trello cards on a specified board for all open issues in specified github repo(s).
 
 ## Usage
 
@@ -9,12 +9,12 @@ After completing [prerequisites](#prerequisites):
 ```
 require 'github_to_trello'
 
-public_key = "your_public_key"
-token = "your_token"
-board_id "your_trello_board_id"
-repo_name = "your_name/your_repo"
-
-GithubToTrello.new(public_key, token, board_id, repo_name).update
+GithubToTrello.new(
+  :public_key => "your_public_key",
+  :token => "your_token",
+  :board_id => "your_trello_board_id",
+  :inbox_name => "your_name/your_repo",
+).update
 ```
 
 ## Prerequisites
@@ -23,7 +23,7 @@ GithubToTrello.new(public_key, token, board_id, repo_name).update
 2. A public key and token giving access to that trello account
    - `PUBLIC_KEY` - Log into trello and visit https://trello.com/app-key
    - `TOKEN` - Go to
-     https://trello.com/1/connect?key=...&name=MyApp&response_type=token&scope=read,write 
+     https://trello.com/1/connect?key=...&name=MyApp&response_type=token&scope=read,write
     (substituting the public key for ... a unique name for MyApp)
 
 ## Features
@@ -35,3 +35,4 @@ GithubToTrello.new(public_key, token, board_id, repo_name).update
 Sites used for reference
 - http://www.sitepoint.com/customizing-trello-ruby/
 - https://github.com/jeremytregunna/ruby-trello/blob/master/lib/trello/card.rb
+

--- a/spec/trello_gateway_spec.rb
+++ b/spec/trello_gateway_spec.rb
@@ -3,12 +3,13 @@ require_relative '../lib/github_to_trello/trello_gateway'
 
 describe TrelloGateway do
   before(:each) do
-    public_key = "56acdaa7404ebcc8bbaffab18428d4d2"
-    token = "08f4481d00aba0091592ad9e0ce7e025ac9e238ead31852fe4a75270fbd562e9"
-    board_id = "5jGWvKui"
-    repo = "django_blog"
+    @gateway = TrelloGateway.new(
+      :public_key => "56acdaa7404ebcc8bbaffab18428d4d2",
+      :token => "08f4481d00aba0091592ad9e0ce7e025ac9e238ead31852fe4a75270fbd562e9",
+      :board_id => "5jGWvKui",
+      :repo_name => "django_blog",
+    )
 
-    @gateway = TrelloGateway.new(public_key, token, board_id, repo)
     @issue = double(:issue,
       :title => "Test",
       :id => "91374795",
@@ -21,23 +22,14 @@ describe TrelloGateway do
   after(:each) do
     @gateway.board.lists.each do |list|
       list.cards.each(&:delete)
+      list.close!
     end
   end
 
   describe "initialization" do
-    it "has a list named for the repo" do
-      expect(@gateway.list).to be_a Trello::List
-      expect(@gateway.list.name).to eq("django_blog")
-    end
-
-    it "has a list called 'Claimed'" do
-      expect(@gateway.list).to be_a Trello::List
-      expect(@gateway.claimed_list.name).to eq("Claimed")
-    end
-
-    it "has a list called 'Done'" do
-      expect(@gateway.list).to be_a Trello::List
-      expect(@gateway.done_list.name).to eq("Done")
+    it "creates the inbox list" do
+      expect(@gateway.inbox).to be_a Trello::List
+      expect(@gateway.inbox.name).to eq("django_blog")
     end
 
     it "has a board" do
@@ -45,29 +37,21 @@ describe TrelloGateway do
     end
   end
 
-  describe "_existing_card?" do
-    it "returns the existing trello card if the card exists in it's repos list" do
+  describe "_existing_card" do
+    it "returns the existing trello card if the card exists in the inbox folder" do
       card = @gateway.create_or_update_card(@issue)
 
-      existing_card = @gateway._existing_card?(@issue) 
+      existing_card = @gateway._existing_card(@issue)
       expect(existing_card).to be_a(Trello::Card)
       expect(existing_card.name).to eq("Test")
     end
 
-    it "returns the existing trello card if the card exists in the 'Claimed' list" do
+    it "returns the existing trello card if the card exists in list other than the inbox" do
+      other_list = Trello::List.create(:name => "some other list", :board_id => @gateway.board.id)
       card = @gateway.create_or_update_card(@issue)
-      card.move_to_list(@gateway.claimed_list.id)
+      card.move_to_list(other_list.id)
 
-      existing_card = @gateway._existing_card?(@issue) 
-      expect(existing_card).to be_a(Trello::Card)
-      expect(existing_card.name).to eq("Test")
-    end
-
-    it "returns the existing trello card if the card exists in the 'Done' list" do
-      card = @gateway.create_or_update_card(@issue)
-      card.move_to_list(@gateway.done_list.id)
-
-      existing_card = @gateway._existing_card?(@issue) 
+      existing_card = @gateway._existing_card(@issue)
       expect(existing_card).to be_a(Trello::Card)
       expect(existing_card.name).to eq("Test")
     end
@@ -83,9 +67,21 @@ describe TrelloGateway do
 
       @gateway.create_or_update_card(not_the_issue)
 
-      existing_card = @gateway._existing_card?(@issue) 
+      existing_card = @gateway._existing_card(@issue)
       expect(existing_card).to be_nil
     end
+  end
+
+  describe "lists" do
+      it "presents all lists on the board" do
+        expect(@gateway.lists.count).to eq(1)
+        expect(@gateway.lists.first).to be_a Trello::List
+        expect(@gateway.lists.first.name).to eq("django_blog")
+        5.times do |number|
+          Trello::List.create(:name => "list_number_#{number}", :board_id => @gateway.board.id)
+        end
+        expect(@gateway.lists.count).to eq(6)
+      end
   end
 
   describe "create_or_update_card" do
@@ -113,48 +109,22 @@ describe TrelloGateway do
       expect(card.name).to eq("Test")
     end
 
-    it "does not add a duplicate card if card exists in a list called 'claimed'" do
-      issue = double(:issue,
-        :title => "Test",
-        :id => "91374795",
-        :updated_at => Date.today.to_s,
-        :body => "This is a test",
-        :html_url => "https://github.com/chrissiedeist/django_blog/issues/1",
-      )
+    it "does not add a duplicate card if card exists in a list" do
+      card = @gateway.create_or_update_card(@issue)
+      expect(card.list.name).to eq("django_blog")
+      expect(@gateway.inbox.cards.length).to eq(1)
 
-      @gateway.claimed_list.cards.length.should == 0
+      other_list = Trello::List.create(:name => "some other list", :board_id => @gateway.board.id)
+      expect(other_list.cards.length).to eq(0)
 
-      card = @gateway.create_or_update_card(issue)
-      card.list.name.should == "django_blog"
+      card.move_to_list(other_list.id)
+      expect(other_list.cards.length).to eq(1)
+      expect(@gateway.inbox.cards.length).to eq(0)
 
-      card.move_to_list(@gateway.claimed_list.id)
-      card = @gateway.create_or_update_card(issue)
-
-      card.list.name.should == "Claimed"
-      @gateway.claimed_list.cards.length.should == 1
-      @gateway.list.cards.length.should == 0
-    end
-
-    it "does not add a duplicate card if card exists in a list called 'done'" do
-      issue = double(:issue,
-        :title => "Test",
-        :id => "91374795",
-        :updated_at => Date.today.to_s,
-        :body => "This is a test",
-        :html_url => "https://github.com/chrissiedeist/django_blog/issues/1",
-      )
-
-      @gateway.done_list.cards.length.should == 0
-
-      card = @gateway.create_or_update_card(issue)
-      card.list.name.should == "django_blog"
-
-      card.move_to_list(@gateway.done_list.id)
-      card = @gateway.create_or_update_card(issue)
-
-      card.list.name.should == "Done"
-      @gateway.done_list.cards.length.should == 1
-      @gateway.list.cards.length.should == 0
+      card = @gateway.create_or_update_card(@issue)
+      expect(card.list.name).to eq("some other list")
+      expect(other_list.cards.length).to eq(1)
+      expect(@gateway.inbox.cards.length).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Switch to dynamically pulling lists from the trello board instead of assuming set
Change init to options hash for more flexible minor releases
Change `repo_name` to inbox name to allow for clarity
