### PR TITLE
Remove checklists on newly created cards

### DIFF
--- a/lib/github_to_trello/trello_gateway.rb
+++ b/lib/github_to_trello/trello_gateway.rb
@@ -44,19 +44,11 @@ class TrelloGateway
   end
 
   def _create_card(issue)
-    card = Trello::Card.create(
+    Trello::Card.create(
       :name => issue.title,
       :list_id => inbox.id,
       :desc => issue.body + "\n" + issue.html_url + "\n" + issue.updated_at.to_s,
     )
-    _add_checklist_to(card)
-    card
-  end
-
-  def _add_checklist_to(card)
-    checklist = Trello::Checklist.create(:name => "Todo", :board_id => board.id)
-    checklist.add_item("Initial Response")
-    card.add_checklist(checklist)
   end
 
   def _board(id)

--- a/spec/integration/trello_gateway_spec.rb
+++ b/spec/integration/trello_gateway_spec.rb
@@ -96,15 +96,6 @@ describe TrelloGateway do
       expect(card.list.name).to eq("django_blog")
     end
 
-    it "includes a checklist with item for initial response when creating cards" do
-      card = @gateway.create_or_update_card(@issue)
-      expect(card.checklists.length).to eq 1
-
-      checklist = card.checklists.first
-      expect(checklist.items.length).to eq 1
-      expect(checklist.items.first.name).to eq "Initial Response"
-    end
-
     it "does not add a duplicate card if card exits in list already" do
       card = @gateway.create_or_update_card(@issue)
       card = @gateway.create_or_update_card(@issue)


### PR DESCRIPTION
[Trello updated their API](https://developers.trello.com/advanced-reference/checklist#post-1-checklists) so that the `card_id` is needed when creating a checklist. 

Seeing as how [ruby-trello has not released a versioned fix for this](https://github.com/jeremytregunna/ruby-trello/issues/159) and the checklists are not being used as much, they can just be removed. 
